### PR TITLE
Task 001 solution: fix Placeholder RuntimeException

### DIFF
--- a/Android/app/src/main/java/com/imobile3/groovypayments/ui/main/MainDashboardActivity.java
+++ b/Android/app/src/main/java/com/imobile3/groovypayments/ui/main/MainDashboardActivity.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import com.imobile3.groovypayments.R;
-import com.imobile3.groovypayments.logging.LogHelper;
 import com.imobile3.groovypayments.ui.BaseActivity;
 import com.imobile3.groovypayments.ui.adapter.MainDashboardButton;
 import com.imobile3.groovypayments.ui.adapter.MainDashboardButtonAdapter;
@@ -19,7 +18,6 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 
 public class MainDashboardActivity extends BaseActivity {
 
@@ -89,16 +87,14 @@ public class MainDashboardActivity extends BaseActivity {
                 break;
 
             case Management:
-                LogHelper.writeWithTrace(Level.INFO, TAG, "Management area not implemented");
-                break;
-
             case TimeTracking:
-                LogHelper.writeWithTrace(Level.INFO, TAG, "Time Tracking area not implemented");
-                break;
-
             case Placeholder1:
             case Placeholder2:
-                throw new RuntimeException("User clicked a Placeholder button");
+                showAlertDialog(
+                        R.string.common_under_construction,
+                        R.string.under_construction_alert_message,
+                        R.string.common_acknowledged);
+                break;
         }
     }
 


### PR DESCRIPTION
## Summary:
This is my proposed solution for BRD Task #001. I changed the switch case logic to remove the logging 
statements and `RuntimeException` (when a **Placeholder** button is clicked) and instead show a 
"Under Construction" dialog. How does it look?

## Test Plan:
- Deploy the Groovy app to a Pixel 2 emulator.
- Click on the Log In button.
- On the Main Dashboard screen, click on either of the "Placeholder" buttons.
- Confirm the app doesn't crash.

## Additional Thoughts:
I removed some of the logs that are published to logcat, because they're basically "TODO" placeholder
verbiage. However, maybe these would be beneficial to keep around.
Also, since the `RuntimeException` has been removed, it now just shows a Placeholder Alert Dialog
with text that isn't very helpful to the user. Maybe we should remove the buttons from the UI instead?

## Related Issue(s):
https://jira.imobile3.com/browse/ABC-1234