### PR TITLE
Upgrade gradle build tools to 7.3.1 and add prelim Kotlin support

### DIFF
--- a/Android/.idea/jarRepositories.xml
+++ b/Android/.idea/jarRepositories.xml
@@ -26,5 +26,10 @@
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$USER_HOME$/.m2/repository/" />
+    </remote-repository>
   </component>
 </project>

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -1,13 +1,14 @@
 apply plugin: 'com.android.application'
 apply from: 'constants.gradle'
+apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {
         applicationId "com.imobile3.groovypayments"
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name=".ui.SplashActivity">
+        <activity
+            android:name=".ui.SplashActivity"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -27,6 +29,7 @@
 
         <activity
             android:name=".ui.main.MainDashboardActivity"
+            android:exported="true"
             android:permission="${applicationId}.permission.START_ACTIVITY"
             android:screenOrientation="behind"
             android:windowSoftInputMode="stateHidden|adjustPan">

--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -1,12 +1,29 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    // Define versions in a single place
+    ext {
+        // Sdk and tools
+        compileSdkVersion = 33
+        minSdkVersion = 21
+        targetSdkVersion = 33
+
+        // App dependencies
+        gradleVersion = '4.1.1'
+        junitVersion = '4.12'
+        kotlinVersion = '1.7.20'
+    }
+
     repositories {
+        mavenLocal()
         google()
         jcenter()
+        mavenCentral()
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +32,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         google()
         jcenter()
         maven { url 'https://jitpack.io' } // Chart/Graph repo

--- a/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jan 26 13:55:50 EST 2020
+#Thu Mar 23 15:19:37 EDT 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Summary:
- Update the `gradle-wrappers.properties` file
- Update the root `build.gradle` file with `ext` block and version declarations
- Update app `build.gradle` to apply plugin `kotlin-android`
